### PR TITLE
Circumvent AttributeError when pushing tags

### DIFF
--- a/igcommit/git.py
+++ b/igcommit/git.py
@@ -98,7 +98,11 @@ class Commit(object):
     def get_author(self):
         if not self.content_fetched:
             self._fetch_content()
-        return self._author
+        # When pushing tags there is no author attribute
+        try:
+            return self._author
+        except AttributeError:
+            return ''
 
     def get_committer(self):
         if not self.content_fetched:


### PR DESCRIPTION
This is to fix this problem:
```
$ git tag -a example ae68de323acdc8181f9133c49749fd059ec7e23c
$ git push --tags

remote: An error occurred, but the commits are accepted.
remote: Traceback (most recent call last):
remote:   File "/usr/lib/python2.7/dist-packages/igcommit/prereceive.py", line 101, in main
remote:     state = Runner().run()
remote:   File "/usr/lib/python2.7/dist-packages/igcommit/prereceive.py", line 34, in run
remote:     check.print_problems()
remote:   File "/usr/lib/python2.7/dist-packages/igcommit/base_check.py", line 75, in print_problems
remote:     for severity, problem in self.get_problems():
remote:   File "/usr/lib/python2.7/dist-packages/igcommit/commit_list_checks.py", line 80, in get_problems
remote:     author_timestamp = commit.get_author().timestamp
remote:   File "/usr/lib/python2.7/dist-packages/igcommit/git.py", line 101, in get_author
remote:     return self._author
remote: AttributeError: 'Commit' object has no attribute '_author'
```