### PR TITLE
Support tags

### DIFF
--- a/igcommit/commit_list_checks.py
+++ b/igcommit/commit_list_checks.py
@@ -61,10 +61,10 @@ class CheckMisleadingMergeCommit(CommitListCheck):
     merge_template = "Merge branch '{}'"
 
     def get_problems(self):
-        ref_name = self.commit_list.ref_path.rsplit('/', 1)[-1]
+        branch_name = self.commit_list.branch_name
         for commit in self.commit_list:
             summary = commit.get_summary()
-            if summary.startswith(self.merge_template.format(ref_name)):
+            if summary.startswith(self.merge_template.format(branch_name)):
                 yield Severity.WARNING, 'merge commit to itself'
             elif summary.startswith(self.merge_template.format('master')):
                 yield Severity.WARNING, 'merge commit master'

--- a/igcommit/git.py
+++ b/igcommit/git.py
@@ -18,15 +18,14 @@ class CommitList(list):
     """Routines on a list of sequential commits"""
     ref_path = None
 
-    def __init__(self, other, ref_path=None):
+    def __init__(self, other, branch_name):
         super(CommitList, self).__init__(other)
-        if ref_path:
-            self.ref_path = ref_path
+        self.branch_name = branch_name
 
     def __str__(self):
         name = '{}..{}'.format(self[0], self[-1])
         if self.ref_path:
-            name += ' ({})'.format(self.ref_path)
+            name += ' ({})'.format(self.branch_name)
         return name
 
 
@@ -52,7 +51,7 @@ class Commit(object):
     def __eq__(self, other):
         return isinstance(other, Commit) and self.commit_id == other.commit_id
 
-    def get_new_commit_list(self, ref_path):
+    def get_new_commit_list(self, branch_name):
         """Get the list of parent new commits in order"""
         output = check_output([
             git_exe_path,
@@ -62,7 +61,7 @@ class Commit(object):
             '--all',
             '--reverse',
         ]).decode('utf-8')
-        commit_list = CommitList([], ref_path)
+        commit_list = CommitList([], branch_name)
         for commit_id in output.splitlines():
             commit = Commit(commit_id, commit_list)
             commit_list.append(commit)


### PR DESCRIPTION
This provides a basic support for the Git tags.  The previous version
was just crashing when a tag is pushed.  This now skips the checks on
list of commits, and applies the checks for single commits to the tags.
Surprisingly, the checks for single commits work on the tags, and
the checks for the committed files don't apply.

We would probably improve the support for tags.  We can check perhaps
relate them with the appropriate list of commits, and cross check
properties like the contributors.