### PR TITLE
Fix CheckContributors()

### DIFF
--- a/igcommit/base_check.py
+++ b/igcommit/base_check.py
@@ -82,6 +82,7 @@ class BaseCheck(object):
         self.set_state(CheckState.DONE)
 
     def evaluate_problems(self):
+        assert self.state == CheckState.CLONED
         for severity, problem in self.get_problems():
             if severity <= Severity.ERROR:
                 self.set_state(CheckState.FAILED)

--- a/igcommit/commit_list_checks.py
+++ b/igcommit/commit_list_checks.py
@@ -133,9 +133,11 @@ class CheckContributors(CommitListCheck):
     def prepare(self, obj):
         new = super(CheckContributors, self).prepare(obj)
         if new and isinstance(obj, CommitList):
-            self.email_index = {}
-            self.domain_index = {}
-            self.name_index = {}
+            new.email_index = {}
+            new.domain_index = {}
+            new.name_index = {}
+
+        return new
 
     def get_problems(self):
         old_contributors = self.get_old_contributors()


### PR DESCRIPTION
The contributor checks were broken because of "return" being missing.

Reported-by: ChaN Wu <chan15tw@gmail.com>
