### PR TITLE
Reduce severity of length for merge commit summary

### DIFF
--- a/igcommit/commit_checks.py
+++ b/igcommit/commit_checks.py
@@ -137,7 +137,11 @@ class CheckCommitSummary(CommitCheck):
 
         rest_len = len(rest)
         if rest_len > 72:
-            yield Severity.ERROR, 'commit summary longer than 72 characters'
+            if rest.startswith('Merge branch '):
+                sev = Severity.WARNING
+            else:
+                sev = Severity.ERROR
+            yield sev, 'commit summary longer than 72 characters'
         elif rest_len > 50:
             yield Severity.WARNING, 'commit summary longer than 50 characters'
 


### PR DESCRIPTION
Merge commit summaries are almost always created automatically with the branch name in it. We should not indirectly limit the length of a branch name by limiting merge commit summaries.