### PR TITLE
Fix rubocop checker

### DIFF
--- a/igcommit/config.py
+++ b/igcommit/config.py
@@ -133,10 +133,15 @@ checks.append(CheckCommand(
 
 # Ruby
 checks.append(CheckCommand(
-    args=['rubocop', '--format=emacs', '--stdin', '/dev/stdin'],
+    args=['rubocop', '--format=emacs', '--stdin'],
     extension='rb',
     exe_pattern=file_extensions['rb'],
     config_files=[CommittedFile('.rubocop.yml')],
+    # Rubocop takes a FILE argument when using --stdin. This file is not
+    # actually loaded, but only used for stuff like "Exclude" directives.
+    # Otherwise, it would not be possible to exclude specific files in this
+    # scenario. The file contents must still be written to stdin.
+    append_filepath=True,
 ))
 
 # Shell

--- a/igcommit/file_checks.py
+++ b/igcommit/file_checks.py
@@ -216,12 +216,9 @@ class CheckCommand(CommittedFileByExtensionCheck):
 
                 # If the file is not changed on this commit, we can skip
                 # downloading.
-                if (prev_commit and (
-                    prev_commit == commit or not config_file.changed()
-                )):
+                if not prev_commit or config_file.changed():
                     with open(config_file.path, 'wb') as fd:
                         fd.write(config_file.get_content())
-
             elif exists(config_file.path):
                 remove(config_file.path)
 

--- a/igcommit/file_checks.py
+++ b/igcommit/file_checks.py
@@ -170,6 +170,7 @@ class CheckCommand(CommittedFileByExtensionCheck):
     config_files = []
     config_required = False
     bogus_return_code = False
+    append_filepath = False
 
     def get_exe_path(self):
         if not self.exe_path:
@@ -225,12 +226,11 @@ class CheckCommand(CommittedFileByExtensionCheck):
         return config_exists
 
     def _prepare_proc(self):
-        self._proc = Popen(
-            [self.get_exe_path()] + self.args[1:],
-            stdin=PIPE,
-            stdout=PIPE,
-            stderr=STDOUT,
-        )
+        args = [self.get_exe_path()] + self.args[1:]
+        if self.append_filepath:
+            args.append(self.committed_file.path)
+
+        self._proc = Popen(args, stdin=PIPE, stdout=PIPE, stderr=STDOUT)
         try:
             with self._proc.stdin as fd:
                 fd.write(self.committed_file.get_content())


### PR DESCRIPTION
This fixes the "Exclude" directives of rubocop as well as refreshing the config files in general