### PR TITLE
Add optional branch name regexp check

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,7 @@ Features
 * Accept commits tagged as ``[HOTFIX]``, ``[MESS]``, ``[TEMP]``, or ``[WIP]``
   with issues
 * Check executable bits and shebangs
+* Check for allowed branch names
 * Check symlinks
 * Check CSS files with ``csslint``
 * Check Go files with ``golint``
@@ -209,6 +210,9 @@ Version 3.1
 
 Version 3.2
     * Reduce severity of length for merge commit summary to warning
+
+Version 3.3
+    * Add optional branch name check via regular expressions
 
 
 License

--- a/igcommit/__init__.py
+++ b/igcommit/__init__.py
@@ -4,4 +4,4 @@ Copyright (c) 2021 InnoGames GmbH
 Portions Copyright (c) 2021 Emre Hasegeli
 """
 
-VERSION = (3, 2)
+VERSION = (3, 3)

--- a/igcommit/config.py
+++ b/igcommit/config.py
@@ -19,6 +19,7 @@ from igcommit.commit_list_checks import (
     CheckDuplicateCommitSummaries,
     CheckMisleadingMergeCommit,
     CheckTimestamps,
+    CheckBranchNameRegexp,
 )
 from igcommit.file_checks import (
     CheckCommand,
@@ -35,6 +36,9 @@ checks.append(CheckDuplicateCommitSummaries())
 checks.append(CheckMisleadingMergeCommit())
 checks.append(CheckTimestamps())
 checks.append(CheckContributors())
+checks.append(CheckBranchNameRegexp(
+    config_files=[CommittedFile('.igcommit-branch-name.conf')]
+))
 
 # Commit checks
 checks.append(CheckCommitMessage())


### PR DESCRIPTION
I am not too happy code-wise since I had to duplicate/modify some stuff, but as far as I can test this one works.
The check is optional like others, enabled when `.igcommit-branch-name.conf` file is found on the repository root.